### PR TITLE
Move `wrap` task to run before `watch` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,5 +31,5 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-wrap');
 
-  grunt.registerTask('default', ['uglify', 'wrap', 'watch']);
+  grunt.registerTask('default', ['wrap', 'uglify', 'watch']);
 }


### PR DESCRIPTION
**Reason:** The `watch` task blocks any other task, so `wrap` task is never executed
