### PR TITLE
Add `window`, `document` and `undefined` variables to the immediately-invoked function expression

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
         dest: 'instanthangouts-<%= pkg.version %>.uncompiled.js',
         options: {
           indent: '  ',
-          wrapper: ['(function () {\n', '}());\n']
+          wrapper: ['(function (window, document, undefined) {\n', '})(window, document);\n']
         }
       }
     }


### PR DESCRIPTION
`undefined` is used here as the undefined global variable in ECMAScript 3 is mutable (ie. it can be changed by someone else). `undefined` isn't really being passed in so we can ensure the value of it is truly undefined. In ES5, `undefined` can no longer be modified.

`window` and `document` are passed through as local variable rather than global as this (slightly) quickens the resolution process and can be more efficiently minified.
- http://stackoverflow.com/questions/15777519/using-window-document-and-undefined-as-arguments-in-anonymous-function-th
- http://stackoverflow.com/questions/15030334/jquery-scripts-functionwindow-document-undefined-vs-function-window-d
- http://hughajwood.wordpress.com/2012/09/12/nothing-is-iffy-with-iife-in-javascript/
